### PR TITLE
Update content-security-policy-parser to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/EdisonLabs/content-security-policy-merger#readme",
   "dependencies": {
-    "content-security-policy-parser": "^0.4.1"
+    "content-security-policy-parser": "^0.5.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.2",


### PR DESCRIPTION
`content-security-policy-parser` versions <0.5.0 have a minor prototype pollution bug with untrusted input.

This updates to the latest version to address that issue.